### PR TITLE
Cambio estilo datetime eventbrite.

### DIFF
--- a/scrapers/eventscraper/spiders/eventbrite.py
+++ b/scrapers/eventscraper/spiders/eventbrite.py
@@ -16,31 +16,33 @@ class EventBrite(CrawlSpider):
             yield scrapy.Request(cabecera.extract(), callback=self.parse_details)            
 
     def parse_details(self, response):
-        if (response.request.url == 'https://www.eventbrite.es/e/entradas-aftertest-madrid-testing-en-produccion-de-devops-a-devtestops-59008004530?aff=ebdssbdestsearch'):
-            pruebota = 2            
         group_and_namelocation = response.xpath('//h2[contains(@class, "listing-map-card-title text-medium")]/text()').extract()        
         if (len(group_and_namelocation) == 0):
             group_and_namelocation.append("")
         abstract = self.getAbstract(response)
         date_str = response.xpath('//div[@class="event-details hide-small"]/div[@class="event-details__data"]/meta/@content').extract_first()
+        date_str = self.getTimeStamp(date_str)
         location = self.getLocation(response)
-        event = Event()
-        event['source'] = 'eventbrite'
-        event['title'] = self.getTitle(response)
-        event['group'] = self.cleanString(group_and_namelocation[0])
-        event['abstract'] = abstract
-        event['abstract_details'] = textwrap.shorten(abstract, width=150, placeholder="...")
-        event['target_url'] = response.request.url
-        event['datetime'] = self.getTimeStamp(date_str)
-        event['location'] = location
-        event['price'] = self.getPrice(response)
-        yield event
+
+        if (location['query'] != "" and not date_str is None):
+            event = Event()
+            event['source'] = 'eventbrite'
+            event['title'] = self.getTitle(response)
+            event['group'] = self.cleanString(group_and_namelocation[0])
+            event['abstract'] = abstract
+            event['abstract_details'] = textwrap.shorten(abstract, width=150, placeholder="...")
+            event['target_url'] = response.request.url
+            event['datetime'] = date_str
+            event['location'] = location
+            event['price'] = self.getPrice(response)
+            yield event
 
     def getTimeStamp(self, date_str): 
         if (date_str is None):
             return None
         date  = parse(date_str)#datetime.strptime(date_str, '%Y-%m-%dT%H:%M:%S')
-        return calendar.timegm(date.utctimetuple())
+        date_str = str(calendar.timegm(date.utctimetuple()))
+        return date_str+'000'
     
     def getTitle(self, response):
         title = response.xpath('//span[@class="summary"]/text()').extract_first()       


### PR DESCRIPTION
Los eventos que no tengan location no se añaden. Se ha añadido a la parte final del timespan '000' para que sea compatible con los eventos de meetup