### PR TITLE
 Add link in README.md to its english version

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,10 @@
 [![Code of conduct](https://img.shields.io/badge/code%20of-conduct-ff69b4.svg?style=flat-square)](https://github.com/OSWeekends/eventpoints-backend/blob/master/CODE_OF_CONDUCT.md)
 ![GitHub](https://img.shields.io/github/license/OSWeekends/osw-hacktoberfest-2019?color=blue&style=flat-square)
 
+## Languages
+
+The English version of this Readme can be read in [here](https://github.com/OSWeekends/eventpoints-backend/blob/master/README-en.md).
+
 ## Sobre EventPoints
 
 EventPoints es uno de los proyectos desarrollados dentro de la comunidad [Open Source Weekends](http://osweekends.com/).


### PR DESCRIPTION
 I wasn't too sure where to put the language section, so if you prefer it to be somewhere else tell me and I will change it. I think this addition is useful while the Spanish Readme is the main one.
